### PR TITLE
Docs and changed to unique_ptr ParticleGenerator

### DIFF
--- a/includes/ParticleGenerator.h
+++ b/includes/ParticleGenerator.h
@@ -16,8 +16,10 @@
  */
 #pragma once
 
-#include "linmath/float3.h"
+#include <memory>
 #include <vector>
+
+#include "linmath/float3.h"
 #include "IRenderComponent.h"
 
 #define LINEAR_SCALE_FACTOR 50.0f
@@ -28,11 +30,41 @@ class Texture;
 class Particle;
 class ParticleConf;
 
+
+/**
+ * \brief Component that generates, handles and renders particles.
+ *
+ * ParticleGenerator has three main responsabilities:
+ *
+ * 1. Generating particles
+ * 2. Updating particles
+ * 3. Rendering particles
+ *
+ * All particles are spawned at a position relative to the GameObject
+ * that the ParticleGenerator is attached to.
+ *
+ * Each particle is updated via a ParticleConf. The ParticleGenerator does
+ * not interfere in the calculations but handles what ParticleConf to use.
+ *
+ * If the camera is far away the ParticleGenerator adapts by not spawning
+ * as many particles.
+ */
 class ParticleGenerator : public IRenderComponent
 {
 public:
+
+    /**
+     * \brief Creates a ParticleGenerator that spawns particles with a given Texture
+     *
+     * @param texture The texture that each particle will use while rendering.
+     * @param amount  The maximum amount of particles to spawn (less particles are spawned
+     *                when the camera is far away).
+     * @param camera  A reference to the active Camera in the scene. Used to rotate particles
+     *                towards the camera and compensate for camera distance.
+     * @param conf    The ParticleConf that will be used while updating the particles.
+     */
     ParticleGenerator(Texture *texture, int amount,
-                      Camera *camera, chag::float4x4 modelMatrix,
+                      Camera *camera,
                       ParticleConf *conf);
 
     ~ParticleGenerator();
@@ -54,17 +86,21 @@ public:
      */
     void render();
 
+    /**
+     * Set how much the level of detail scales with distance to camera
+     */
     void setScaleLod(bool value);
 
-    void setLooping(bool value);
 private:
-    std::vector<Particle*> m_particles;
     GLuint m_vaob;
     Texture *texture;
+
     int m_amount = 0;
     Camera *m_camera;
 
-    ParticleConf *conf;
+    std::vector<std::unique_ptr<Particle>> m_particles;
+
+    std::unique_ptr<ParticleConf> conf;
     bool doScale = true;
 
     chag::float3x3 getModelMatrix3x3();

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -17,23 +17,23 @@
 #include "particle/Particle.h"
 #include "ParticleConf.h"
 
-Particle::Particle(ParticleConf *conf, chag::float4x4 modelMatrix) {
+Particle::Particle(ParticleConf &conf, chag::float4x4 modelMatrix) {
     reset(conf, modelMatrix);
 };
 
-void Particle::reset(ParticleConf *conf, chag::float4x4 modelMatrix) {
-    position = conf->initialPosition();
+void Particle::reset(ParticleConf &conf, chag::float4x4 modelMatrix) {
+    position = conf.initialPosition();
     chag::float4 vec = chag::make_vector(position.x, position.y, position.z, 1.0f);
     chag::float4 mat = modelMatrix * vec;
     position.x = mat.x;
     position.y = mat.y;
     position.z = mat.z;
-    velocity = conf->initialVelocity();
-    life     = conf->calcLifetime();
+    velocity = conf.initialVelocity();
+    life     = conf.calcLifetime();
 }
 
-void Particle::update(float deltaTime, float distanceToCam, ParticleConf *conf) {
-    velocity    = conf->accelerate(velocity);
+void Particle::update(float deltaTime, float distanceToCam, ParticleConf &conf) {
+    velocity    = conf.accelerate(velocity);
     position   += velocity * deltaTime / 1000;
     life       -= deltaTime + (distanceToCam * 2);
 }

--- a/src/particle/Particle.h
+++ b/src/particle/Particle.h
@@ -31,14 +31,14 @@ class ParticleConf;
 class Particle {
 
 public:
-    Particle(ParticleConf *conf, chag::float4x4 modelMatrix);
+    Particle(ParticleConf &conf, chag::float4x4 modelMatrix);
 
     /**
      * Resets the particle according to the given ParticleConf.
      * This is used in order to reuse particles.
      * @param conf The ParticleConf to used by the ParticleGenerator.
      */
-    void reset(ParticleConf *conf, chag::float4x4 modelMatrix);
+    void reset( ParticleConf &conf, chag::float4x4 modelMatrix);
 
     /**
      * @return If the Particle is alive, that is visible, or not.
@@ -51,7 +51,7 @@ public:
      * @param distanceToCam The distance from camera in units.
      * @param conf The ParticleConf used by the ParticleGenerator.
      */
-    void update(float deltaTime, float distanceToCam, ParticleConf *conf);
+    void update(float deltaTime, float distanceToCam, ParticleConf &conf);
     chag::float3 getPosition();
 
 private:


### PR DESCRIPTION
Started to write documentation for ParticleGenerator and half way through I noticed that there were some parts that could easily be cleaned up, so I did.
- The constructor no longer takes a model matrix. Instead the attached GameObjects model matrix is used instead.
- There are no longer any traditional pointers used. Instead ParticleGenerator uses std::unique_ptr. This is especially nice since the Particles are automatically cleaned up which did not happen at all before.
