### PR TITLE
Refactoring ParticleGenerator

### DIFF
--- a/includes/ParticleGenerator.h
+++ b/includes/ParticleGenerator.h
@@ -16,8 +16,10 @@
  */
 #pragma once
 
-#include "linmath/float3.h"
+#include <memory>
 #include <vector>
+
+#include "linmath/float3.h"
 #include "IRenderComponent.h"
 
 #define LINEAR_SCALE_FACTOR 50.0f
@@ -28,11 +30,41 @@ class Texture;
 class Particle;
 class ParticleConf;
 
+
+/**
+ * \brief Component that generates, handles and renders particles.
+ *
+ * ParticleGenerator has three main responsabilities:
+ *
+ * 1. Generating particles
+ * 2. Updating particles
+ * 3. Rendering particles
+ *
+ * All particles are spawned at a position relative to the GameObject
+ * that the ParticleGenerator is attached to.
+ *
+ * Each particle is updated via a ParticleConf. The ParticleGenerator does
+ * not interfere in the calculations but handles what ParticleConf to use.
+ *
+ * If the camera is far away the ParticleGenerator adapts by not spawning
+ * as many particles.
+ */
 class ParticleGenerator : public IRenderComponent
 {
 public:
+
+    /**
+     * \brief Creates a ParticleGenerator that spawns particles with a given Texture
+     *
+     * @param texture The texture that each particle will use while rendering.
+     * @param amount  The maximum amount of particles to spawn (less particles are spawned
+     *                when the camera is far away).
+     * @param camera  A reference to the active Camera in the scene. Used to rotate particles
+     *                towards the camera and compensate for camera distance.
+     * @param conf    The ParticleConf that will be used while updating the particles.
+     */
     ParticleGenerator(Texture *texture, int amount,
-                      Camera *camera, chag::float4x4 modelMatrix,
+                      Camera *camera,
                       ParticleConf *conf);
 
     ~ParticleGenerator();
@@ -54,17 +86,21 @@ public:
      */
     void render();
 
+    /**
+     * Set how much the level of detail scales with distance to camera
+     */
     void setScaleLod(bool value);
 
-    void setLooping(bool value);
 private:
-    std::vector<Particle*> m_particles;
     GLuint m_vaob;
     Texture *texture;
+
     int m_amount = 0;
     Camera *m_camera;
 
-    ParticleConf *conf;
+    std::vector<std::unique_ptr<Particle>> m_particles;
+
+    std::unique_ptr<ParticleConf> conf;
     bool doScale = true;
 
     chag::float3x3 getModelMatrix3x3();

--- a/includes/ParticleGenerator.h
+++ b/includes/ParticleGenerator.h
@@ -19,35 +19,25 @@
 #include <memory>
 #include <vector>
 
-#include "linmath/float3.h"
 #include "IRenderComponent.h"
 
-#define LINEAR_SCALE_FACTOR 50.0f
-#define LOD_FACTOR 25.0f
 
 class Camera;
-class Texture;
 class Particle;
 class ParticleConf;
+class ParticleRenderer;
 
 
 /**
  * \brief Component that generates, handles and renders particles.
  *
- * ParticleGenerator has three main responsabilities:
- *
- * 1. Generating particles
- * 2. Updating particles
- * 3. Rendering particles
+ * ParticleGenerator manages spawns and updates particles.
  *
  * All particles are spawned at a position relative to the GameObject
  * that the ParticleGenerator is attached to.
  *
  * Each particle is updated via a ParticleConf. The ParticleGenerator does
  * not interfere in the calculations but handles what ParticleConf to use.
- *
- * If the camera is far away the ParticleGenerator adapts by not spawning
- * as many particles.
  */
 class ParticleGenerator : public IRenderComponent
 {
@@ -56,16 +46,17 @@ public:
     /**
      * \brief Creates a ParticleGenerator that spawns particles with a given Texture
      *
-     * @param texture The texture that each particle will use while rendering.
-     * @param amount  The maximum amount of particles to spawn (less particles are spawned
-     *                when the camera is far away).
-     * @param camera  A reference to the active Camera in the scene. Used to rotate particles
-     *                towards the camera and compensate for camera distance.
-     * @param conf    The ParticleConf that will be used while updating the particles.
+     * @param maxParticles  The maximum amount of particles to spawn (less particles are spawned
+     *                     when the camera is far away).
+     * @param renderer     The ParticleRenderer that will be used to render particles.
+     * @param conf         The ParticleConf that will be used while updating the particles.
+     * @param camera       A reference to the active Camera in the scene. Used to compensate for
+     *                     camera distance when updating Particles.
      */
-    ParticleGenerator(Texture *texture, int amount,
-                      Camera *camera,
-                      ParticleConf *conf);
+    ParticleGenerator(int maxParticles,
+                      std::shared_ptr<ParticleRenderer> renderer,
+                      std::shared_ptr<ParticleConf> conf,
+                      std::shared_ptr<Camera> camera);
 
     ~ParticleGenerator();
 
@@ -86,22 +77,14 @@ public:
      */
     void render();
 
-    /**
-     * Set how much the level of detail scales with distance to camera
-     */
-    void setScaleLod(bool value);
-
 private:
-    GLuint m_vaob;
-    Texture *texture;
 
-    int m_amount = 0;
-    Camera *m_camera;
+    int maxParticles = 0;
 
-    std::vector<std::unique_ptr<Particle>> m_particles;
+    std::vector<std::unique_ptr<Particle>> particles;
 
-    std::unique_ptr<ParticleConf> conf;
-    bool doScale = true;
+    std::shared_ptr<ParticleRenderer> renderer;
+    std::shared_ptr<ParticleConf> conf;
+    std::shared_ptr<Camera> camera;
 
-    chag::float3x3 getModelMatrix3x3();
 };

--- a/includes/ParticleRenderer.h
+++ b/includes/ParticleRenderer.h
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Bubba-3D.
+ *
+ * Bubba-3D is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bubba-3D is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Bubba-3D. If not, see http://www.gnu.org/licenses/.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "linmath/float3.h"
+
+#define LINEAR_SCALE_FACTOR 50.0f
+#define LOD_FACTOR 25.0f
+class Texture;
+class Camera;
+class ShaderProgram;
+class ParticleConf;
+class Particle;
+
+/**
+ * \bief Responsible for rendering particles
+ *
+ * ParticleRenderer renders Particles. Typically the particles are provided
+ * by a ParticleGenerator.
+ */
+class ParticleRenderer
+{
+public:
+    /**
+     * \breif Creates a particle Renderer that renders particles
+     *
+     * @param texture The texture to use on the particles.
+     * @param camera  A reference to the active Camera in the scene. Used to rotate particles
+     *                towards the camera and compensate for camera distance.
+     * @param shader  A reference to the ShaderProgram used.
+     */
+    ParticleRenderer(std::shared_ptr<Texture> texture,
+                     std::shared_ptr<Camera> camera,
+                     std::shared_ptr<ShaderProgram> shaderProgram=defaultShader());
+
+    ~ParticleRenderer();
+
+    /**
+     * \brief render particles in the scene.
+     *
+     * @param particles The particles to render.
+     */
+    void render(std::vector<std::unique_ptr<Particle>> &particles,
+                const chag::float3 &position,
+                const std::shared_ptr<ParticleConf> &conf);
+
+    static std::shared_ptr<ShaderProgram> defaultShader();
+
+private:
+    GLuint vaob;
+
+    std::shared_ptr<Texture> texture;
+    std::shared_ptr<Camera> camera;
+    std::shared_ptr<ShaderProgram> shaderProgram;
+};
+

--- a/src/particle/CMakeLists.txt
+++ b/src/particle/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(BUBBA3D_FILES_SOURCE particle/Particle.cpp
                          particle/ParticleGenerator.cpp
+                         particle/ParticleRenderer.cpp
                          ${BUBBA3D_FILES_SOURCE}
                          PARENT_SCOPE)

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -17,23 +17,23 @@
 #include "particle/Particle.h"
 #include "ParticleConf.h"
 
-Particle::Particle(ParticleConf *conf, chag::float4x4 modelMatrix) {
+Particle::Particle(ParticleConf &conf, chag::float4x4 modelMatrix) {
     reset(conf, modelMatrix);
 };
 
-void Particle::reset(ParticleConf *conf, chag::float4x4 modelMatrix) {
-    position = conf->initialPosition();
+void Particle::reset(ParticleConf &conf, chag::float4x4 modelMatrix) {
+    position = conf.initialPosition();
     chag::float4 vec = chag::make_vector(position.x, position.y, position.z, 1.0f);
     chag::float4 mat = modelMatrix * vec;
     position.x = mat.x;
     position.y = mat.y;
     position.z = mat.z;
-    velocity = conf->initialVelocity();
-    life     = conf->calcLifetime();
+    velocity = conf.initialVelocity();
+    life     = conf.calcLifetime();
 }
 
-void Particle::update(float deltaTime, float distanceToCam, ParticleConf *conf) {
-    velocity    = conf->accelerate(velocity);
+void Particle::update(float deltaTime, float distanceToCam, ParticleConf &conf) {
+    velocity    = conf.accelerate(velocity);
     position   += velocity * deltaTime / 1000;
     life       -= deltaTime + (distanceToCam * 2);
 }

--- a/src/particle/Particle.h
+++ b/src/particle/Particle.h
@@ -31,14 +31,14 @@ class ParticleConf;
 class Particle {
 
 public:
-    Particle(ParticleConf *conf, chag::float4x4 modelMatrix);
+    Particle(ParticleConf &conf, chag::float4x4 modelMatrix);
 
     /**
      * Resets the particle according to the given ParticleConf.
      * This is used in order to reuse particles.
      * @param conf The ParticleConf to used by the ParticleGenerator.
      */
-    void reset(ParticleConf *conf, chag::float4x4 modelMatrix);
+    void reset( ParticleConf &conf, chag::float4x4 modelMatrix);
 
     /**
      * @return If the Particle is alive, that is visible, or not.
@@ -51,7 +51,7 @@ public:
      * @param distanceToCam The distance from camera in units.
      * @param conf The ParticleConf used by the ParticleGenerator.
      */
-    void update(float deltaTime, float distanceToCam, ParticleConf *conf);
+    void update(float deltaTime, float distanceToCam, ParticleConf &conf);
     chag::float3 getPosition();
 
 private:

--- a/src/particle/ParticleGenerator.cpp
+++ b/src/particle/ParticleGenerator.cpp
@@ -16,6 +16,7 @@
  */
 #include <ResourceManager.h>
 #include "ParticleGenerator.h"
+#include "ParticleRenderer.h"
 #include "constants.h"
 #include "linmath/float3x3.h"
 #include "Camera.h"
@@ -23,128 +24,37 @@
 #include "ParticleConf.h"
 
 
-ParticleGenerator::ParticleGenerator(Texture *texture, int amount,
-                                     Camera *camera, ParticleConf *conf)
-                                   : texture(texture), m_amount(amount),
-                                     m_camera(camera), conf(conf)
+ParticleGenerator::ParticleGenerator(int maxParticles,
+                                     std::shared_ptr<ParticleRenderer> renderer,
+                                     std::shared_ptr<ParticleConf> conf,
+                                     std::shared_ptr<Camera> camera)
+                                   : maxParticles(maxParticles),
+                                     renderer(renderer),
+                                     conf(conf),
+                                     camera(camera)
 {
-    ResourceManager::loadShader("shaders/particle.vert", "shaders/particle.frag", "particleShader");
-    shaderProgram = ResourceManager::getShader("particleShader");
-    shaderProgram->setUniformBufferObjectBinding(UNIFORM_BUFFER_OBJECT_MATRICES_NAME,
-                                                 UNIFORM_BUFFER_OBJECT_MATRICES_INDEX);
-    GLfloat quad[] = { //POSITION3 TEXCOORD2
-        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-        1.0f, 1.0f, 0.0f, 1.0f, 1.0f,
-        0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
-    
-        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-        1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
-        1.0f, 1.0f, 0.0f, 1.0f, 1.0f,
-    };
-    
-    glGenVertexArrays(1, &m_vaob);
-    glBindVertexArray(m_vaob);
-    
-    GLuint pos_vbo;
-    glGenBuffers(1, &pos_vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, pos_vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
-    
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), 0);
-    
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), (void*)(3 * sizeof(GLfloat)));
-    
-    /* CLEANUP */
-    glBindVertexArray(0);
-    
 }
 
 
 ParticleGenerator::~ParticleGenerator()
 {
-
 }
-
-void ParticleGenerator::setScaleLod(bool value) {
-    doScale = value;
-}
-
-
 
 void ParticleGenerator::render() {
-    glDisable(GL_CULL_FACE);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, conf->blendFunc);
-    
-    shaderProgram->backupCurrentShaderProgram();
-    shaderProgram->use();
-    
-    texture->bind(GL_TEXTURE0);
-    
-    shaderProgram->setUniform3f("color", chag::make_vector(1.0f, 1.0f, 1.0f));
-    shaderProgram->setUniform1i("sprite", 0);
-    
-    chag::float3x3 modelMatrix3x3 = getModelMatrix3x3();
-    
-    float distance = length(m_camera->getPosition() - owner->getAbsoluteLocation());
-    int maxParticles = (int)(m_amount * LOD_FACTOR / distance );
-    glBindVertexArray(m_vaob);
-    
-
-    // Sort the particles
-    std::sort(m_particles.begin(), m_particles.end(), [this] (const std::unique_ptr<Particle> &p1,
-                                                              const std::unique_ptr<Particle> &p2)
-    {
-        float l1 = length(m_camera->getPosition() - p1->getPosition());
-        float l2 = length(m_camera->getPosition() - p2->getPosition());
-    
-        return l1 > l2;
-    });
-
-    // Render the particles
-    int iterations = 0;
-    for (std::unique_ptr<Particle> &particle : m_particles) {
-        if (iterations > maxParticles) { break; }
-        iterations++;
-    
-        chag::float3 scale;
-        if (particle->isAlive()) {
-            if(doScale) {
-                scale = conf->calcParticleScale() * (1.0 + distance / LINEAR_SCALE_FACTOR);
-            } else {
-                scale = chag::make_vector(1.0f, 1.0f, 1.0f);
-            }
-            chag::float4x4 modelMatrix4x4 = make_matrix(modelMatrix3x3, particle->getPosition())
-                                                      * chag::make_scale<chag::float4x4>(scale);
-    
-            shaderProgram->setUniformMatrix4fv("modelMatrix", modelMatrix4x4);
-    
-            glDrawArrays(GL_TRIANGLES, 0, 6);
-        }
-    }
-    
-    /* CLEANUP */
-    glBindVertexArray(0);
-    shaderProgram->restorePreviousShaderProgram();
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glDisable(GL_BLEND);
-    
-    glEnable(GL_CULL_FACE);
+    renderer->render(particles, owner->getAbsoluteLocation(), conf);
 }
 
 void ParticleGenerator::update(float dt) {
-    if (m_particles.empty() && owner != nullptr) {
-        for (int i = 0; i < m_amount; i++) {
+    if (particles.empty() && owner != nullptr) {
+        for (int i = 0; i < maxParticles; i++) {
             std::unique_ptr<Particle> part(new Particle(*conf, owner->getModelMatrix()));
-            m_particles.push_back(std::move(part));
+            particles.push_back(std::move(part));
         }
     }
 
-    float distance = length(m_camera->getPosition() - owner->getAbsoluteLocation());
+    float distance = length(camera->getPosition() - owner->getAbsoluteLocation());
 
-    for (std::unique_ptr<Particle> &particle : m_particles) {
+    for (std::unique_ptr<Particle> &particle : particles) {
         if (particle->isAlive()){
             particle->update(dt, distance, *conf);
         }
@@ -152,14 +62,4 @@ void ParticleGenerator::update(float dt) {
             particle->reset(*conf, owner->getModelMatrix());
         }
     }
-}
-
-chag::float3x3 ParticleGenerator::getModelMatrix3x3() {
-    chag::float3 u = chag::normalize(m_camera->getUp());
-    chag::float3 n = chag::normalize(m_camera->getLookAt() - m_camera->getPosition());
-    chag::float3 r = chag::normalize(chag::cross(u, n));
-
-    chag::float3 uprim = chag::cross(n, r);
-    
-    return make_matrix(r, uprim, n);
 }

--- a/src/particle/ParticleRenderer.cpp
+++ b/src/particle/ParticleRenderer.cpp
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Bubba-3D.
+ *
+ * Bubba-3D is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bubba-3D is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Bubba-3D. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "linmath/float3x3.h"
+
+#include "ResourceManager.h"
+#include "constants.h"
+
+#include "Camera.h"
+#include "ShaderProgram.h"
+#include "Particle.h"
+#include "ParticleRenderer.h"
+#include "ParticleConf.h"
+
+
+ParticleRenderer::ParticleRenderer(std::shared_ptr<Texture> texture,
+                                   std::shared_ptr<Camera> camera,
+                                   std::shared_ptr<ShaderProgram> shaderProgram)
+                                 : texture(texture),
+                                   camera(camera),
+                                   shaderProgram(shaderProgram)
+{
+    GLfloat quad[] = { //POSITION3 TEXCOORD2
+        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        1.0f, 1.0f, 0.0f, 1.0f, 1.0f,
+        0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+    
+        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+        1.0f, 1.0f, 0.0f, 1.0f, 1.0f,
+    };
+    
+    glGenVertexArrays(1, &vaob);
+    glBindVertexArray(vaob);
+    
+    GLuint pos_vbo;
+    glGenBuffers(1, &pos_vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, pos_vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), 0);
+    
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), (void*)(3 * sizeof(GLfloat)));
+    
+    /* CLEANUP */
+    glBindVertexArray(0);
+    
+}
+
+ParticleRenderer::~ParticleRenderer()
+{
+
+}
+
+std::shared_ptr<ShaderProgram> ParticleRenderer::defaultShader()
+{
+    ResourceManager::loadShader("shaders/particle.vert", "shaders/particle.frag", "particleShader");
+    std::shared_ptr<ShaderProgram> shaderProgram(ResourceManager::getShader("particleShader"));
+
+    shaderProgram->setUniformBufferObjectBinding(UNIFORM_BUFFER_OBJECT_MATRICES_NAME,
+                                                 UNIFORM_BUFFER_OBJECT_MATRICES_INDEX);
+
+    return shaderProgram;
+}
+
+void ParticleRenderer::render(std::vector<std::unique_ptr<Particle>> &particles,
+                              const chag::float3 &position,
+                              const std::shared_ptr<ParticleConf> &conf) {
+    glDisable(GL_CULL_FACE);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, conf->blendFunc);
+    
+    shaderProgram->backupCurrentShaderProgram();
+    shaderProgram->use();
+    
+    texture->bind(GL_TEXTURE0);
+    
+    shaderProgram->setUniform3f("color", chag::make_vector(1.0f, 1.0f, 1.0f));
+    shaderProgram->setUniform1i("sprite", 0);
+    
+    chag::float3 u = chag::normalize(camera->getUp());
+    chag::float3 n = chag::normalize(camera->getLookAt() - camera->getPosition());
+    chag::float3 r = chag::normalize(chag::cross(u, n));
+
+    chag::float3 uprim = chag::cross(n, r);
+    
+    chag::float3x3 modelMatrix3x3 = make_matrix(r, uprim, n);
+    
+    float distance = length(camera->getPosition() - position);
+    int maxParticles = (int)(particles.size() * LOD_FACTOR / distance );
+    glBindVertexArray(vaob);
+    
+
+    // Sort the particles
+    std::sort(particles.begin(), particles.end(), [this] (const std::unique_ptr<Particle> &p1,
+                                                              const std::unique_ptr<Particle> &p2)
+    {
+        float l1 = length(camera->getPosition() - p1->getPosition());
+        float l2 = length(camera->getPosition() - p2->getPosition());
+    
+        return l1 > l2;
+    });
+
+    // Render the particles
+    int iterations = 0;
+
+    chag::float3 scale = conf->calcParticleScale() * (1.0 + distance / LINEAR_SCALE_FACTOR);
+    chag::float4x4 scaleMatrix = chag::make_scale<chag::float4x4>(scale);
+    for (std::unique_ptr<Particle> &particle : particles) {
+        if (iterations > maxParticles) { break; }
+        iterations++;
+    
+        if (particle->isAlive()) {
+            chag::float4x4 modelMatrix4x4 = make_matrix(modelMatrix3x3, particle->getPosition())
+                                          * scaleMatrix;
+             
+            shaderProgram->setUniformMatrix4fv("modelMatrix", modelMatrix4x4);
+            glDrawArrays(GL_TRIANGLES, 0, 6);
+        }
+    }
+    
+    /* CLEANUP */
+    glBindVertexArray(0);
+    shaderProgram->restorePreviousShaderProgram();
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDisable(GL_BLEND);
+    
+    glEnable(GL_CULL_FACE);
+}


### PR DESCRIPTION
Started to write documentation for ParticleGenerator and half way through I noticed that there were some parts that could easily be cleaned up, so I did.

```
The constructor no longer takes a model matrix. Instead the attached GameObjects model matrix is used instead.
There are no longer any traditional pointers used. Instead ParticleGenerator uses std::unique_ptr. This is especially nice since the Particles are automatically cleaned up which did not happen at all before.
```
