### PR TITLE
ResourceManager uses shared ptrs

### DIFF
--- a/includes/GLSquare.h
+++ b/includes/GLSquare.h
@@ -19,6 +19,7 @@
 #include <GL/glew.h>
 #include <linmath/float4x4.h>
 #include <IHudDrawable.h>
+#include <memory>
 
 class ShaderProgram;
 class HUDGraphic;
@@ -44,7 +45,7 @@ public:
 
     void updateGraphic();
 
-    virtual void render(ShaderProgram* shaderProgram, chag::float4x4* projectionMatrix);
+    virtual void render(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4* projectionMatrix);
 
 protected:
     float posX;
@@ -55,7 +56,7 @@ protected:
     HUDGraphic* graphic;
     GLuint vao;
 
-    ShaderProgram* shaderProgram;
+    std::shared_ptr<ShaderProgram> shaderProgram;
     chag::float4x4* projectionMatrix;
     chag::float3 originalPosition;
 
@@ -63,6 +64,6 @@ protected:
 
     void init(float posX, float posY, float width, float height, HUDGraphic* image);
     void fillVertexBuffer();
-    void bindTextureAndDraw(ShaderProgram* shaderProgram, chag::float4x4* projectionMatrix);
+    void bindTextureAndDraw(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4* projectionMatrix);
     void updateOriginalPosition();
 };

--- a/includes/GameObject.h
+++ b/includes/GameObject.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <linmath/Quaternion.h>
 #include <Sphere.h>
-#include "ShaderProgram.h"
+#include <memory>
 
 enum EventType {BeforeCollision, DuringCollision, AfterCollision};
 
@@ -33,6 +33,7 @@ class Triangle;
 class IRenderComponent;
 class IComponent;
 class Octree;
+class ShaderProgram;
 
 /**
  * \brief A class for containing all information about a object in the game world.
@@ -95,7 +96,7 @@ public:
     /**
      * Renders the GameObject shadows using the GameObjects RenderComponent, if any.
      */
-    virtual void renderShadow(ShaderProgram* shaderProgram);
+    virtual void renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram);
 
     void addRenderComponent(IRenderComponent* renderer);
     void addComponent(IComponent* newComponent);

--- a/includes/HudRenderer.h
+++ b/includes/HudRenderer.h
@@ -37,7 +37,7 @@ public:
     ~HudRenderer();
 
     virtual void render();
-    virtual void renderShadow(ShaderProgram *shaderProgram);
+    virtual void renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram);
     virtual void update(float dt);
 
     /**

--- a/includes/IDrawable.h
+++ b/includes/IDrawable.h
@@ -14,8 +14,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Bubba-3D. If not, see http://www.gnu.org/licenses/.
  */
-#ifndef __IDRAWABLE_H__
-#define __IDRAWABLE_H__
+#pragma once
+
+#include <memory>
 
 class ShaderProgram;
 
@@ -26,10 +27,7 @@ public:
 	virtual ~IDrawable(){};
 
   virtual void render() = 0;
-  virtual void renderShadow(ShaderProgram* shaderProgram) = 0;
+  virtual void renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram) = 0;
   
   float shininess;
 };
-
-
-#endif

--- a/includes/IHudDrawable.h
+++ b/includes/IHudDrawable.h
@@ -18,6 +18,7 @@
 
 #include <linmath/float3.h>
 #include <linmath/float4x4.h>
+#include <memory>
 
 class ShaderProgram;
 
@@ -27,7 +28,7 @@ class ShaderProgram;
  */
 class IHudDrawable {
 public:
-    virtual void render(ShaderProgram* shaderProgram, chag::float4x4* projectionMatrix) = 0;
+    virtual void render(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4* projectionMatrix) = 0;
 
     /**
      * Sets a position relative to the original position calculated

--- a/includes/IRenderComponent.h
+++ b/includes/IRenderComponent.h
@@ -17,15 +17,15 @@
 #pragma once
 
 #include "IComponent.h"
-#include "ShaderProgram.h"
+#include <memory>
 
 
 class IRenderComponent : public IComponent {
 public:
     virtual void render() = 0;
-    virtual void renderShadow(ShaderProgram *shaderProgram) = 0;
+    virtual void renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram) = 0;
 
 protected:
-    ShaderProgram *shaderProgram;
+    std::shared_ptr<ShaderProgram> shaderProgram;
 
 };

--- a/includes/Material.h
+++ b/includes/Material.h
@@ -14,11 +14,11 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Bubba-3D. If not, see http://www.gnu.org/licenses/.
  */
-#ifndef BUBBA_3D_MATERIAL_H
-#define BUBBA_3D_MATERIAL_H
+#pragma once
 
 #include "linmath/float3.h"
 #include "Texture.h"
+#include <memory>
 
 struct Material {
     chag::float3 diffuseColor;
@@ -26,8 +26,6 @@ struct Material {
     chag::float3 specularColor;
     chag::float3 emissiveColor;
     float specularExponent;
-    Texture *diffuseTexture = NULL;
-    Texture *bumpMapTexture = NULL;
+    std::shared_ptr<Texture> diffuseTexture = NULL;
+    std::shared_ptr<Texture> bumpMapTexture = NULL;
 };
-
-#endif //BUBBA_3D_MATERIAL_H

--- a/includes/Mesh.h
+++ b/includes/Mesh.h
@@ -32,6 +32,7 @@
 class BoneTransformer;
 class Triangle;
 class Chunk;
+class Texture;
 struct BoneInfluenceOnVertex;
 
 /**
@@ -160,8 +161,9 @@ private:
      * @param type A enum saying which texture type to load from the material
      * @return A pointer to the texture loaded
      */
-    Texture* getTexture(const aiMaterial *material, const std::string &fileNameOfMesh,
-                        aiTextureType type);
+    std::shared_ptr<Texture> getTexture(const aiMaterial *material,
+                                        const std::string &fileNameOfMesh,
+                                        aiTextureType type);
 
     /**
      * Initiates OpenGL buffers and buffers the chunk data on to the graphics memory.

--- a/includes/ParticleGenerator.h
+++ b/includes/ParticleGenerator.h
@@ -70,7 +70,7 @@ public:
      * Render shadows from the spawned Particles.
      * @param shaderProgram The ShaderProgram used to render the shadows.
      */
-    void renderShadow(ShaderProgram* shaderProgram) {};
+    void renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram) {};
 
     /**
      * Render all the spawned Particles.

--- a/includes/RelativeIHudDrawable.h
+++ b/includes/RelativeIHudDrawable.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "IHudDrawable.h"
+#include <memory>
 
 class GameObject;
 class Camera;
@@ -25,7 +26,7 @@ class RelativeIHudDrawable : public IHudDrawable {
 public:
 
     RelativeIHudDrawable(Camera* worldCamera, GameObject* relativeTo, IHudDrawable* toDraw);
-    virtual void render(ShaderProgram* shaderProgram, chag::float4x4* projectionMatrix);
+    virtual void render(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4* projectionMatrix);
 
 protected:
     GameObject* relativeTo;

--- a/includes/Renderer.h
+++ b/includes/Renderer.h
@@ -14,23 +14,23 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Bubba-3D. If not, see http://www.gnu.org/licenses/.
  */
-#ifndef __RENDERER_H__
-#define __RENDERER_H__
+#pragma once
 
 #ifdef WIN32
 #include <windows.h>
 #endif
 
 #include "linmath/float4x4.h"
-#include "Utils.h"
 #include "Effects.h"
+#include "Utils.h"
+#include <memory>
 
 #define CUBE_MAP_RESOLUTION	   512
 #define SHADOW_MAP_RESOLUTION  2048
 
-
 class Camera;
 class Scene;
+class ShaderProgram;
 class IDrawable;
 
 class Renderer {
@@ -54,29 +54,26 @@ private:
 
     Fbo createPostProcessFbo(int width, int height);
     void drawShadowMap(Fbo sbo, chag::float4x4 viewProjectionMatrix, Scene *scene);
-    void drawShadowCasters(ShaderProgram* shaderProgram, Scene *scene);
-    void drawTransparent(ShaderProgram* shaderProgram, Scene *scene);
-    void setFog(ShaderProgram* shaderProgram);
-    void setLights(ShaderProgram* shaderProgram, Scene *scene);
+    void drawShadowCasters(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene);
+    void drawTransparent(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene);
+    void setFog(std::shared_ptr<ShaderProgram> &shaderProgram);
+    void setLights(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene);
 
-    ShaderProgram* shaderProgram;
+    std::shared_ptr<ShaderProgram> shaderProgram;
 
     Fbo sbo;
     Camera *cubeMapCameras[6];
 
     // Drawing
-    void drawModel(IDrawable &model, ShaderProgram* shaderProgram);
+    void drawModel(IDrawable &model, std::shared_ptr<ShaderProgram> &shaderProgram);
     void drawFullScreenQuad();
     void renderPostProcess();
     void blurImage();
 
     // Postprocess
-    ShaderProgram* postFxShader;
-    ShaderProgram* horizontalBlurShader;
-    ShaderProgram* verticalBlurShader;
-    ShaderProgram* cutoffShader;
+    std::shared_ptr<ShaderProgram> postFxShader;
+    std::shared_ptr<ShaderProgram> horizontalBlurShader;
+    std::shared_ptr<ShaderProgram> verticalBlurShader;
+    std::shared_ptr<ShaderProgram> cutoffShader;
     Fbo postProcessFbo, horizontalBlurFbo, verticalBlurFbo, cutOffFbo;
 };
-
-
-#endif // __RENDERER_H__

--- a/includes/ResourceManager.h
+++ b/includes/ResourceManager.h
@@ -14,44 +14,86 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Bubba-3D. If not, see http://www.gnu.org/licenses/.
  */
-#ifndef BUBBA_3D_RESOURCEMANAGER_H
-#define BUBBA_3D_RESOURCEMANAGER_H
+#pragma once
 
 #include <map>
-#include "ShaderProgram.h"
-#include "Texture.h"
-#include "Mesh.h"
 #include <sstream>
+#include <memory>
+
+class Texture;
+class Mesh;
+class ShaderProgram;
 
 /**
- * \brief ResourceManager for all resources that can be shared 
+ * @brief ResourceManager for all resources that can be shared 
  *
  * The purpose of this class is to only maintain one copy of
- * each resource in memory and then distribute a pointer to that allocation.
+ * each resource in memory and then distribute them as shared pointers.
  *
  */
 class ResourceManager {
 public:
-    static void loadShader(const std::string &vertexShader, const std::string &fragmentShader, std::string name);
-    static ShaderProgram* getShader(std::string name);
 
-    static Texture* loadAndFetchTexture(const std::string &fileName);
-    static Mesh*    loadAndFetchMesh   (const std::string &fileName);
+    /**
+     * @brief Tries to load a Texture into the ResourceManager and then return it.
+     *
+     * Tries to fetch a Texture from the ResourceManager.
+     * If the Texture is not already loaded it is loaded before being fetched.
+     *
+     * @param shaderName The name of the shader
+     * @param vertexShader The name of the vertexshader file.
+     * @param fragmentShader The name of the fragmenshare file.
+     */
+    static std::shared_ptr<ShaderProgram> loadAndFetchShaderProgram(const std::string &name,
+                                                                    const std::string &vertexShader,
+                                                                    const std::string &fragmentShader);
 
-    template<typename Type>
-    static Type* getItemFromMap(std::map<std::string, Type> *map, std::string id) ;
+    /**
+     * @brief Tries to load a Texture into the ResourceManager and then return it.
+     *
+     * Tries to fetch a Texture from the ResourceManager.
+     * If the Texture is not already loaded it is loaded before being fetched.
+     *
+     * @param fileName The name of the texture file.
+     */
+    static std::shared_ptr<Texture> loadAndFetchTexture(const std::string &fileName);
+
+    /**
+     * @brief Tries to load a Mesh into the ResourceManager and then return it.
+     *
+     * Tries to fetch a Mesh from the ResourceManager.
+     * If the Mesh is not already loaded it is loaded before being fetched.
+     *
+     * @param fileName The name of the mesh file.
+     */
+    static std::shared_ptr<Mesh>    loadAndFetchMesh   (const std::string &fileName);
+
 
 private:
-    static std::map<std::string, ShaderProgram> shaders;
-    static std::map<std::string, Texture> textures;
-    static std::map<std::string, Mesh> meshes;
+    static std::map<std::string, std::shared_ptr<ShaderProgram>> shaders;
+    static std::map<std::string, std::shared_ptr<Texture>> textures;
+    static std::map<std::string, std::shared_ptr<Mesh>> meshes;
+
+    /**
+     * @brief Loads a ShaderProgram into the ResourceManager
+     */
+    static void loadShader(const std::string &vertexShader,
+                           const std::string &fragmentShader,
+                           const std::string &name);
+
+    /**
+     * @brief Gets a already loaded ShaderProgram from the ResourceManager 
+     */
+    static std::shared_ptr<ShaderProgram> getShader(const std::string &name);
 
     static void loadTexture(const std::string &fileName);
-    static Texture* getTexture(std::string fileName);
+    static std::shared_ptr<Texture> getTexture(const std::string &fileName);
 
     static void loadMesh(const std::string &fileName);
-    static Mesh* getMesh(std::string fileName);
+    static std::shared_ptr<Mesh> getMesh(const std::string &fileName);
+
+    template<typename Type>
+    static std::shared_ptr<Type> getItemFromMap(std::map<std::string, std::shared_ptr<Type>> &map,
+                                                const std::string &id) ;
 
 };
-
-#endif //BUBBA_3D_RESOURCEMANAGER_H

--- a/includes/SkyBoxRenderer.h
+++ b/includes/SkyBoxRenderer.h
@@ -18,6 +18,7 @@
 
 #include "IRenderComponent.h"
 #include <string>
+#include <memory>
 
 class Camera;
 class CubeMapTexture;
@@ -35,7 +36,7 @@ public:
               const std::string& posYFilename, const std::string& negYFilename,
               const std::string& posZFilename, const std::string& negZFilename);
 
-    void renderShadow(ShaderProgram* shaderProgram) {};
+    void renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram) {};
     void render();
     void update(float dt);
 private:

--- a/includes/StandardRenderer.h
+++ b/includes/StandardRenderer.h
@@ -14,13 +14,11 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Bubba-3D. If not, see http://www.gnu.org/licenses/.
  */
-#ifndef BUBBA_3D_STANDARDRENDERER_H
-#define BUBBA_3D_STANDARDRENDERER_H
-
+#pragma once
 
 #include "IRenderComponent.h"
 #include "SFML/Window.hpp"
-
+#include <memory>
 
 class Mesh;
 class ShaderProgram;
@@ -37,12 +35,12 @@ class Chunk;
 class StandardRenderer : public IRenderComponent {
 public:
     StandardRenderer();
-    StandardRenderer(Mesh*, GameObject*, ShaderProgram*);
+    StandardRenderer(Mesh*, GameObject*, std::shared_ptr<ShaderProgram>);
 
     void update(float dt);
 
     void render();
-    void renderShadow(ShaderProgram *shaderProgram);
+    void renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram);
 private:
     Mesh* mesh;
     GameObject *gameObject;
@@ -50,4 +48,3 @@ private:
 };
 
 
-#endif //BUBBA_3D_STANDARDRENDERER_H

--- a/includes/TextObject.h
+++ b/includes/TextObject.h
@@ -19,6 +19,7 @@
 #include <IHudDrawable.h>
 #include <GL/glew.h>
 #include <vector>
+#include <memory>
 
 /**
  * A low-level OpenGL object that renders text within the specified dimensions.
@@ -38,7 +39,7 @@ public:
      * matrix. The shader should have the same variables as the default hud.vert
      * and hud.frag.
      */
-    void virtual render(ShaderProgram* shaderProgram, chag::float4x4* projectionMatrix);
+    void virtual render(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4* projectionMatrix);
 
     /**
      * Changes the text of the TextObject.

--- a/includes/Utils.h
+++ b/includes/Utils.h
@@ -21,6 +21,7 @@
 #include "linmath/float3.h"
 #include "linmath/float4x4.h"
 #include "assimp/material.h"
+#include <memory>
 
 class ShaderProgram;
 class GameObject;
@@ -29,7 +30,7 @@ class GameObject;
 struct Fbo {
     GLuint id;
     GLuint texture;
-    ShaderProgram* shaderProgram;
+    std::shared_ptr<ShaderProgram> shaderProgram;
     GLuint depthbuffer;
 
     int width, height;

--- a/src/collision/TwoPhaseCollider.cpp
+++ b/src/collision/TwoPhaseCollider.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include "GameObject.h"
 #include "TwoPhaseCollider.h"
+#include "Logger.h"
 
 TwoPhaseCollider::TwoPhaseCollider(BroadPhaseCollider *broadPhaseCollider, ExactPhaseCollider *exactPhaseCollider) {
     this->broadPhaseCollider = broadPhaseCollider;

--- a/src/components/StandardRenderer.cpp
+++ b/src/components/StandardRenderer.cpp
@@ -29,8 +29,8 @@ StandardRenderer::StandardRenderer(){
 
 }
 
-StandardRenderer::StandardRenderer(Mesh* mesh, GameObject* gameObject, ShaderProgram* shaderProgram):
-        mesh(mesh), gameObject(gameObject)
+StandardRenderer::StandardRenderer(Mesh* mesh, GameObject* gameObject, std::shared_ptr<ShaderProgram> shaderProgram)
+                                 : mesh(mesh), gameObject(gameObject)
 {
     this->shaderProgram = shaderProgram;
 }
@@ -96,7 +96,7 @@ void StandardRenderer::render() {
     CHECK_GL_ERROR();
 }
 
-void StandardRenderer::renderShadow(ShaderProgram *shaderProgram) {
+void StandardRenderer::renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram) {
 
     chag::float4x4 modelMatrix = gameObject->getModelMatrix();
     shaderProgram->setUniformMatrix4fv("modelMatrix", modelMatrix);

--- a/src/objects/GameObject.cpp
+++ b/src/objects/GameObject.cpp
@@ -154,7 +154,7 @@ chag::float4x4 GameObject::getModelMatrix() {
 }
 
 
-void GameObject::renderShadow(ShaderProgram *shaderProgram) {
+void GameObject::renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram) {
     renderComponent->renderShadow(shaderProgram);
     for (GameObject *child : children) {
         child->renderShadow(shaderProgram);

--- a/src/objects/Mesh.cpp
+++ b/src/objects/Mesh.cpp
@@ -31,6 +31,7 @@
 #include "Utils.h"
 #include "linmath/float3x3.h"
 #include "BoneTransformer.h"
+#include "Texture.h"
 
 using namespace chag;
 
@@ -200,7 +201,10 @@ float3 Mesh::getColorFromMaterial(const char* colorTypeString, unsigned int type
     return make_vector(color.r, color.g, color.b);
 }
 
-Texture *Mesh::getTexture(const aiMaterial *material, const std::string &fileNameOfMesh, aiTextureType type) {
+std::shared_ptr<Texture> Mesh::getTexture(const aiMaterial *material,
+                                          const std::string &fileNameOfMesh,
+                                          aiTextureType type)
+{
     aiString texturePath;
     if (material->GetTexture(type, 0, &texturePath, NULL, NULL, NULL, NULL, NULL) != AI_SUCCESS) {
         return NULL;

--- a/src/objects/SkyBoxRenderer.cpp
+++ b/src/objects/SkyBoxRenderer.cpp
@@ -21,6 +21,8 @@
 #include "CubeMapTexture.h"
 #include "GameObject.h"
 #include "Chunk.h"
+#include "ShaderProgram.h"
+#include "Mesh.h"
 
 #define SKYBOX_SHADER_NAME "skybox_shader"
 
@@ -32,8 +34,7 @@ bool SkyBoxRenderer::init(const std::string &posXFilename, const std::string &ne
                           const std::string &posZFilename, const std::string &negZFilename)
 {
     m_pCubemap = new CubeMapTexture(posXFilename, negXFilename, posYFilename, negYFilename, posZFilename, negZFilename);
-    ResourceManager::loadShader("shaders/skybox.vert", "shaders/skybox.frag", SKYBOX_SHADER_NAME);
-    shaderProgram = ResourceManager::getShader(SKYBOX_SHADER_NAME);
+    shaderProgram = ResourceManager::loadAndFetchShaderProgram(SKYBOX_SHADER_NAME, "shaders/skybox.vert", "shaders/skybox.frag");
     shaderProgram->setUniformBufferObjectBinding(UNIFORM_BUFFER_OBJECT_MATRICES_NAME, UNIFORM_BUFFER_OBJECT_MATRICES_INDEX);
 
     return true;

--- a/src/particle/ParticleRenderer.cpp
+++ b/src/particle/ParticleRenderer.cpp
@@ -25,6 +25,7 @@
 #include "Particle.h"
 #include "ParticleRenderer.h"
 #include "ParticleConf.h"
+#include "Texture.h"
 
 
 ParticleRenderer::ParticleRenderer(std::shared_ptr<Texture> texture,
@@ -69,8 +70,7 @@ ParticleRenderer::~ParticleRenderer()
 
 std::shared_ptr<ShaderProgram> ParticleRenderer::defaultShader()
 {
-    ResourceManager::loadShader("shaders/particle.vert", "shaders/particle.frag", "particleShader");
-    std::shared_ptr<ShaderProgram> shaderProgram(ResourceManager::getShader("particleShader"));
+    std::shared_ptr<ShaderProgram> shaderProgram = ResourceManager::loadAndFetchShaderProgram( "particleShader", "shaders/particle.vert", "shaders/particle.frag");
 
     shaderProgram->setUniformBufferObjectBinding(UNIFORM_BUFFER_OBJECT_MATRICES_NAME,
                                                  UNIFORM_BUFFER_OBJECT_MATRICES_INDEX);

--- a/src/userInterface/GLSquare.cpp
+++ b/src/userInterface/GLSquare.cpp
@@ -25,7 +25,7 @@
 #include <ResourceManager.h>
 #include <Globals.h>
 
-void GLSquare::render(ShaderProgram* shaderProgram, chag::float4x4* projectionMatrix) {
+void GLSquare::render(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4* projectionMatrix) {
 
     GLint currentDepthFunc;
     glGetIntegerv(GL_DEPTH_FUNC, &currentDepthFunc);
@@ -47,7 +47,7 @@ void GLSquare::render(ShaderProgram* shaderProgram, chag::float4x4* projectionMa
     shaderProgram->restorePreviousShaderProgram();
 }
 
-void GLSquare::bindTextureAndDraw(ShaderProgram *shaderProgram, chag::float4x4* projectionMatrix) {
+void GLSquare::bindTextureAndDraw(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4* projectionMatrix) {
     shaderProgram->use();
     glBindVertexArray(vao);
 

--- a/src/userInterface/HudRenderer.cpp
+++ b/src/userInterface/HudRenderer.cpp
@@ -34,8 +34,7 @@ using namespace std;
 
 HudRenderer::HudRenderer(){
 
-    ResourceManager::loadShader("shaders/hud.vert", "shaders/hud.frag", "hudShader");
-    shaderProgram = ResourceManager::getShader("hudShader");
+    shaderProgram = ResourceManager::loadAndFetchShaderProgram("hudShader", "shaders/hud.vert", "shaders/hud.frag");
 
 }
 
@@ -91,7 +90,7 @@ HudRenderer::~HudRenderer(){
 }
 
 
-void HudRenderer::renderShadow(ShaderProgram *shaderProgram) {}
+void HudRenderer::renderShadow(std::shared_ptr<ShaderProgram> &shaderProgram) {}
 
 void HudRenderer::update(float dt){
     int x = Globals::get(Globals::MOUSE_WINDOW_X);

--- a/src/userInterface/RelativeIHudDrawable.cpp
+++ b/src/userInterface/RelativeIHudDrawable.cpp
@@ -18,11 +18,12 @@
 #include <Globals.h>
 #include "RelativeIHudDrawable.h"
 #include "Camera.h"
+#include <memory>
 
 RelativeIHudDrawable::RelativeIHudDrawable(Camera* worldCamera, GameObject *relativeTo, IHudDrawable *toDraw) :
         relativeTo(relativeTo), toDraw(toDraw), worldCamera(worldCamera) {}
 
-void RelativeIHudDrawable::render(ShaderProgram *shaderProgram, chag::float4x4 *projectionMatrix) {
+void RelativeIHudDrawable::render(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4 *projectionMatrix) {
 
     chag::float3 drawableRelativePosition = toDraw->relativePosition;
     chag::float4x4 screenPos = worldCamera->getProjectionMatrix()

--- a/src/userInterface/TextObject.cpp
+++ b/src/userInterface/TextObject.cpp
@@ -176,7 +176,7 @@ void TextObject::initAndBindBuffers() {
 
 }
 
-void TextObject::render(ShaderProgram *shaderProgram, chag::float4x4 *projectionMatrix) {
+void TextObject::render(std::shared_ptr<ShaderProgram> shaderProgram, chag::float4x4 *projectionMatrix) {
 
     GLint currentDepthFunc;
     glGetIntegerv(GL_DEPTH_FUNC, &currentDepthFunc);


### PR DESCRIPTION
Changed so that the ResourceManager uses std::shared_ptr<Type> instead of Type*
to store resources. Also changed so that ShaderProgram follows the same pattern
as Texture and Mesh.
