### PR TITLE
Added GPU based wind

### DIFF
--- a/includes/Effects.h
+++ b/includes/Effects.h
@@ -62,17 +62,9 @@ struct Bloom {
     }
 };
 
-struct Wind {
-      chag::float3 force;
-
-    Wind() {
-        force = chag::make_vector(0.0f, 0.0f, 0.0f);
-    }
-};
 
 struct Effects {
     Fog fog;
     Blur blur;
     Bloom bloom;
-    Wind wind;
 };

--- a/includes/Effects.h
+++ b/includes/Effects.h
@@ -62,8 +62,17 @@ struct Bloom {
     }
 };
 
+struct Wind {
+      chag::float3 force;
+
+    Wind() {
+        force = chag::make_vector(0.0f, 0.0f, 0.0f);
+    }
+};
+
 struct Effects {
     Fog fog;
     Blur blur;
     Bloom bloom;
+    Wind wind;
 };

--- a/includes/GameObject.h
+++ b/includes/GameObject.h
@@ -19,6 +19,7 @@
 #include "IDrawable.h"
 #include "AABB2.h"
 #include "linmath/float4x4.h"
+#include "WindAffection.h"
 #include <vector>
 #include <linmath/Quaternion.h>
 #include <Sphere.h>
@@ -65,7 +66,7 @@ class ShaderProgram;
  * has been marked as dirty. Then you can at a later point, when calculations arent being done,
  * safely remove the object.
  */
-class GameObject : public IDrawable, public std::enable_shared_from_this<GameObject> {
+class GameObject : public IDrawable, public std::enable_shared_from_this<GameObject>, public WindAffection {
 public:
     GameObject();
     GameObject(std::shared_ptr<GameObject> parent);

--- a/includes/IShader.h
+++ b/includes/IShader.h
@@ -30,13 +30,14 @@
 class IShader {
 public:
     virtual void compile() = 0;
-    virtual void checkErrors() = 0;
+    virtual void checkErrors(GLuint &shader) = 0;
     virtual GLuint getGLId() = 0;
 
     GLuint compileShader(GLenum type, const char *source) {
         GLuint compiledShader = glCreateShader(type);
         glShaderSource(compiledShader, 1, &source, NULL);
         glCompileShader(compiledShader);
+        checkErrors(compiledShader);
         return compiledShader;
     }
 

--- a/includes/Mesh.h
+++ b/includes/Mesh.h
@@ -129,6 +129,9 @@ private:
     chag::float3 getColorFromMaterial(const char* colorTypeString, unsigned int type,
                                       unsigned int index, const aiMaterial &material);
 
+
+    chag::float3 getVertexColors(const aiMesh *paiMesh, Chunk &chunk, unsigned int i) const;
+
     /**
      * Uses the file name of the mesh to calculate the absolute path to the specified texture
      *
@@ -191,6 +194,7 @@ private:
     AABB aabb;
 
     unsigned int numAnimations;
+
 
 
 };

--- a/includes/Mesh.h
+++ b/includes/Mesh.h
@@ -130,7 +130,7 @@ private:
                                       unsigned int index, const aiMaterial &material);
 
 
-    chag::float3 getVertexColors(const aiMesh *paiMesh, Chunk &chunk, unsigned int i) const;
+    void getVertexColors(const aiMesh *paiMesh, Chunk &chunk, unsigned int i) const;
 
     /**
      * Uses the file name of the mesh to calculate the absolute path to the specified texture

--- a/includes/Renderer.h
+++ b/includes/Renderer.h
@@ -32,6 +32,7 @@ class Camera;
 class Scene;
 class ShaderProgram;
 class IDrawable;
+class Wind;
 
 class Renderer {
 public:
@@ -53,10 +54,6 @@ public:
     Effects effects;
 private:
     float currentTime;
-    float lastWindChangeTime = 0;
-    chag::float3 lastWindSpeed = chag::make_vector(0.0f, 0.0f, 0.0f);
-    chag::float3 currentWindSpeed = chag::make_vector(0.0f, 0.0f, 0.0f);
-    chag::float3 newWindSpeed = chag::make_vector(0.0f, 0.0f, 0.0f);
 
     Fbo createPostProcessFbo(int width, int height);
     void drawShadowMap(Fbo sbo, chag::float4x4 viewProjectionMatrix, Scene *scene);
@@ -64,7 +61,7 @@ private:
     void drawTransparent(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene);
     void setFog(std::shared_ptr<ShaderProgram> &shaderProgram);
     void setLights(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene);
-    void setWind(std::shared_ptr<ShaderProgram> shaderProgram);
+    void setWind(std::shared_ptr<ShaderProgram> shaderProgram, const std::shared_ptr<Wind> ptr);
 
     void drawBloom(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene, int i, int i1, chag::float4x4 &viewProjectionMatrix);
 

--- a/includes/Renderer.h
+++ b/includes/Renderer.h
@@ -85,4 +85,6 @@ private:
     Fbo postProcessFbo, horizontalBlurFbo, verticalBlurFbo;
 
     chag::float3 backgroundColor = chag::make_vector(0.2f, 0.2f, 0.8f);
+
+    void setWindUniforms(std::shared_ptr<ShaderProgram> &shaderProgram, const std::shared_ptr<GameObject> &shadowCaster) const;
 };

--- a/includes/Renderer.h
+++ b/includes/Renderer.h
@@ -74,7 +74,7 @@ private:
 
     Camera *cubeMapCameras[6];
     // Drawing
-    void drawModel(IDrawable &model, std::shared_ptr<ShaderProgram> &shaderProgram);
+    void drawModel(const std::shared_ptr<IDrawable> &model, std::shared_ptr<ShaderProgram> &shaderProgram);
     void drawFullScreenQuad();
 
     void renderPostProcess();

--- a/includes/Renderer.h
+++ b/includes/Renderer.h
@@ -53,6 +53,10 @@ public:
     Effects effects;
 private:
     float currentTime;
+    float lastWindChangeTime = 0;
+    chag::float3 lastWindSpeed = chag::make_vector(0.0f, 0.0f, 0.0f);
+    chag::float3 currentWindSpeed = chag::make_vector(0.0f, 0.0f, 0.0f);
+    chag::float3 newWindSpeed = chag::make_vector(0.0f, 0.0f, 0.0f);
 
     Fbo createPostProcessFbo(int width, int height);
     void drawShadowMap(Fbo sbo, chag::float4x4 viewProjectionMatrix, Scene *scene);
@@ -60,27 +64,28 @@ private:
     void drawTransparent(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene);
     void setFog(std::shared_ptr<ShaderProgram> &shaderProgram);
     void setLights(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene);
+    void setWind(std::shared_ptr<ShaderProgram> shaderProgram);
+
     void drawBloom(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene, int i, int i1, chag::float4x4 &viewProjectionMatrix);
 
     std::shared_ptr<ShaderProgram> shaderProgram;
-
     Fbo sbo;
+
+
     Camera *cubeMapCameras[6];
-
-
     // Drawing
     void drawModel(IDrawable &model, std::shared_ptr<ShaderProgram> &shaderProgram);
     void drawFullScreenQuad();
-    void renderPostProcess();
 
+    void renderPostProcess();
     // Postprocess
     std::shared_ptr<ShaderProgram> postFxShader;
     std::shared_ptr<ShaderProgram> horizontalBlurShader;
     std::shared_ptr<ShaderProgram> verticalBlurShader;
     std::shared_ptr<ShaderProgram> cutoffShader;
     std::shared_ptr<ShaderProgram> emissiveShader;
+
     Fbo postProcessFbo, horizontalBlurFbo, verticalBlurFbo;
 
     chag::float3 backgroundColor = chag::make_vector(0.2f, 0.2f, 0.8f);
-
 };

--- a/includes/Scene.h
+++ b/includes/Scene.h
@@ -21,6 +21,7 @@
 #include "Utils.h"
 #include "Lights.h"
 #include "IDrawable.h"
+#include "Wind.h"
 
 class CubeMapTexture;
 class Camera;
@@ -67,12 +68,17 @@ public:
     std::vector<std::shared_ptr<GameObject>> getShadowCasters();
     std::vector<std::shared_ptr<GameObject>> getTransparentObjects();
 
+    const std::shared_ptr<Wind> getWind() const;
+    void setWind(const std::shared_ptr<Wind> wind);
+
     virtual void update(float dt);
 
 private:
     std::vector<std::shared_ptr<GameObject>> shadowCasters;
     std::vector<std::shared_ptr<GameObject>> transparentObjects;
     std::vector<std::shared_ptr<GameObject>> allObjects;
+
+    std::shared_ptr<Wind> wind;
 
     void removeDirty(std::vector<std::shared_ptr<GameObject>> *v);
 };

--- a/includes/Utils.h
+++ b/includes/Utils.h
@@ -64,3 +64,5 @@ chag::float3x3 convertAiMatrixToFloat3x3(aiMatrix3x3 fromMatrix) ;
 
 typedef std::pair<std::shared_ptr<GameObject>, std::shared_ptr<GameObject>> CollisionPair;
 typedef std::vector<CollisionPair> CollisionPairList;
+
+chag::float3 linearSmoothStep(chag::float3 v1, chag::float3 v2, float time);

--- a/includes/Wind.h
+++ b/includes/Wind.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <linmath/float3.h>
+
+class Wind {
+public:
+    Wind();
+    Wind(const chag::float3 &force);
+
+    const chag::float3 &getForce() const;
+
+private:
+    chag::float3 force;
+
+};
+
+
+

--- a/includes/WindAffection.h
+++ b/includes/WindAffection.h
@@ -1,0 +1,26 @@
+#pragma once
+
+
+class WindAffection {
+public:
+    bool getIsAffectedByWind() const;
+    void setAffectedByWind(bool isAffectedByWind);
+
+    float getMainBendiness() const;
+    void setMainBendiness(float mainBendiness);
+
+    float getBranchAmplitude() const;
+    void setBranchAmplitude(float branchAmplitude);
+
+    float getLeafAmplitude() const;
+    void setLeafAmplitude(float leafAmplitude);
+
+private:
+    bool isAffectedByWind = false;
+    float mainBendiness = 0.0f;
+    float branchAmplitude = 0.0f;
+    float leafAmplitude = 0.0f;
+};
+
+
+

--- a/shaders/simple.frag
+++ b/shaders/simple.frag
@@ -148,6 +148,10 @@ void main()
     vec3 cubeMapSample = vec3(0.0);
     cubeMapSample = calculateCubeMapSample(directionToEye, normal);
 
+    if(object_alpha < 0.1) {
+        discard;
+    }
+
 	fragmentColor = vec4(foggedColor + emissive + cubeMapSample, object_alpha);
 }
 

--- a/shaders/simple.vert
+++ b/shaders/simple.vert
@@ -10,6 +10,7 @@ in vec3 tangent;
 in vec3 bittangent;
 layout(location = 6) in ivec4 boneIds;
 layout(location = 7) in vec4 boneWeights;
+layout(location = 8) in vec3 vertexColor;
 
 out vec4 viewSpacePosition;
 out vec3 worldSpaceNormal;
@@ -27,11 +28,33 @@ uniform int has_animations;
 const int MAX_NUM_BONES = 100;
 uniform mat4 bones[MAX_NUM_BONES];
 
+uniform float time;
+
+uniform vec3 windForce;
+
 layout(std140) uniform Matrices {
     mat4 viewMatrix;
     mat4 projectionMatrix;
     mat4 viewProjectionMatrix;
 };
+
+vec3 applyMainBending(vec3 positionInWorldSpace, vec3 windForce);
+vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpace, float time);
+
+#define SIDE_TO_SIDE_FREQ1 1.975
+#define SIDE_TO_SIDE_FREQ2 0.793
+#define UP_AND_DOWN_FREQ1 0.375
+#define UP_AND_DOWN_FREQ2 0.193
+
+vec4 smoothCurve( vec4 x ) {
+  return x * x * ( 3.0 - 2.0 * x );
+}
+vec4 triangleWave( vec4 x ) {
+  return abs( fract( x + 0.5 ) * 2.0 - 1.0 );
+}
+vec4 smoothTriangleWave( vec4 x ) {
+  return smoothCurve( triangleWave( x ) );
+}
 
 
 void main()
@@ -48,6 +71,12 @@ void main()
         positionInWorldSpace = (boneTransform * vec4(position, 1.0)).xyz;
         normalVectorInWorldSpace = (boneTransform * vec4(normalIn, 0.0)).xyz;
     }
+
+    vec3 objectPositionInWorldSpace = vec3(modelMatrix[3][0], modelMatrix[3][1], modelMatrix[3][2]);
+    //positionInWorldSpace = applyMainBending(positionInWorldSpace - objectPositionInWorldSpace, windForce);
+    //positionInWorldSpace += objectPositionInWorldSpace;
+
+    positionInWorldSpace = applyDetailBending(positionInWorldSpace, objectPositionInWorldSpace, time);
 
 	mat4 modelViewMatrix = viewMatrix * modelMatrix;
 	mat4 modelViewProjectionMatrix = projectionMatrix * modelViewMatrix;
@@ -68,3 +97,36 @@ void main()
 	gl_Position = modelViewProjectionMatrix * vec4(positionInWorldSpace,1.0);
 }
 
+vec3 applyMainBending(vec3 positionInWorldSpace, vec3 windForce) {
+    float vertexHeight = positionInWorldSpace.y * 0.01; // TODO Extract 0.01 var to uniform and set for each gameobject
+    vertexHeight += 1.0;
+    vertexHeight *= vertexHeight;
+    vertexHeight = vertexHeight * vertexHeight - vertexHeight;
+
+    vec3 newPos = positionInWorldSpace;
+    newPos.xy += windForce.xy * vertexHeight;
+
+    float oldLength = length(positionInWorldSpace);
+
+    return normalize(newPos) * oldLength;
+}
+
+vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpace, float time) {
+    float branchAmplitude = 10.0;
+    float branchStiffness = vertexColor.b;
+
+    // Each object has its own phase to allow us to give different animations to different identical objects
+    float objectPhase = dot(objectPositionInWorldSpace, vec3(1));
+
+    float vertexPhase = dot(positionInWorldSpace, vec3(objectPhase));
+
+    vec2 wavesIn = time + vec2(vertexPhase, 0.0);
+    vec4 waves = (fract(wavesIn.xxyy * vec4(SIDE_TO_SIDE_FREQ1, SIDE_TO_SIDE_FREQ2, UP_AND_DOWN_FREQ1, UP_AND_DOWN_FREQ2) * 2.0 - 1.0)) * 2 * 1;
+    waves = smoothTriangleWave(waves);
+    vec2 waveSum = vec2(waves.x + waves.y, waves.z + waves.w);
+
+    //positionInWorldSpace.xzy += waveSum.xxy * vec3(0.0, 0.0, vertexColor.b * 10.0);
+    positionInWorldSpace.y += waveSum.y * branchStiffness * branchAmplitude;
+
+    return positionInWorldSpace;
+}

--- a/shaders/simple.vert
+++ b/shaders/simple.vert
@@ -72,6 +72,8 @@ void main()
         normalVectorInWorldSpace = (boneTransform * vec4(normalIn, 0.0)).xyz;
     }
 
+    positionInWorldSpace = (modelMatrix * vec4(positionInWorldSpace, 1.0)).xyz;
+
     vec3 objectPositionInWorldSpace = vec3(modelMatrix[3][0], modelMatrix[3][1], modelMatrix[3][2]);
     positionInWorldSpace = applyMainBending(positionInWorldSpace - objectPositionInWorldSpace, windForce);
     positionInWorldSpace += objectPositionInWorldSpace;
@@ -117,10 +119,11 @@ vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpa
 
     // Each object has its own phase to allow us to give different animations to different identical objects
     float objectPhase = dot(objectPositionInWorldSpace, vec3(1));
+    float branchPhase = vertexColor.g + objectPhase;
 
-    float vertexPhase = dot(positionInWorldSpace, vec3(objectPhase));
+    float vertexPhase = dot(positionInWorldSpace, vec3(branchPhase));
 
-    vec2 wavesIn = time + vec2(vertexPhase, objectPhase);
+    vec2 wavesIn = time + vec2(vertexPhase, branchPhase);
     vec4 waves = (fract(wavesIn.xxyy * vec4(SIDE_TO_SIDE_FREQ1, SIDE_TO_SIDE_FREQ2, UP_AND_DOWN_FREQ1, UP_AND_DOWN_FREQ2) * 2.0 - 1.0)) * 2 * 1;
     waves = smoothTriangleWave(waves);
     vec2 waveSum = vec2(waves.x + waves.y, waves.z + waves.w);

--- a/shaders/simple.vert
+++ b/shaders/simple.vert
@@ -44,7 +44,7 @@ layout(std140) uniform Matrices {
 };
 
 vec3 applyMainBending(vec3 positionInWorldSpace, vec3 windForce, float mainBendiness);
-vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpace, float branchAmplitude, float leafAmplitude, float time);
+vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 windForce, vec3 objectPositionInWorldSpace, float branchAmplitude, float leafAmplitude, float time);
 
 #define SIDE_TO_SIDE_FREQ1 1.975
 #define SIDE_TO_SIDE_FREQ2 0.793
@@ -85,7 +85,7 @@ void main()
 
         positionInWorldSpace = applyMainBending(positionInWorldSpace - objectPositionInWorldSpace, windForce, mainBendiness);
         positionInWorldSpace += objectPositionInWorldSpace;
-        positionInWorldSpace = applyDetailBending(positionInWorldSpace, objectPositionInWorldSpace, branchAmplitude, leafAmplitude, time);
+        positionInWorldSpace = applyDetailBending(positionInWorldSpace, windForce, objectPositionInWorldSpace, branchAmplitude, leafAmplitude, time);
     }
 
 	mat4 modelViewMatrix = viewMatrix * modelMatrix;
@@ -121,7 +121,7 @@ vec3 applyMainBending(vec3 positionInWorldSpace, vec3 windForce, float mainBendi
     return normalize(newPos) * oldLength;
 }
 
-vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpace, float branchAmplitude, float leafAmplitude, float time) {
+vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 windForce, vec3 objectPositionInWorldSpace, float branchAmplitude, float leafAmplitude, float time) {
     float branchStiffness = vertexColor.b;
 
     // Each object has its own phase to allow us to give different animations to different identical objects
@@ -137,7 +137,7 @@ vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpa
 
     float windStrength = length(windForce);
     positionInWorldSpace.xyz += waveSum.x * vec3(vertexColor.b * windStrength * leafAmplitude * normalIn.xyz);
-    positionInWorldSpace.y += waveSum.y * branchStiffness * branchAmplitude;
+    positionInWorldSpace.y += waveSum.y * branchStiffness * branchAmplitude * windStrength;
 
     return positionInWorldSpace;
 }

--- a/shaders/simple.vert
+++ b/shaders/simple.vert
@@ -120,7 +120,7 @@ vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpa
 
     float vertexPhase = dot(positionInWorldSpace, vec3(objectPhase));
 
-    vec2 wavesIn = time + vec2(vertexPhase, 0.0);
+    vec2 wavesIn = time + vec2(vertexPhase, objectPhase);
     vec4 waves = (fract(wavesIn.xxyy * vec4(SIDE_TO_SIDE_FREQ1, SIDE_TO_SIDE_FREQ2, UP_AND_DOWN_FREQ1, UP_AND_DOWN_FREQ2) * 2.0 - 1.0)) * 2 * 1;
     waves = smoothTriangleWave(waves);
     vec2 waveSum = vec2(waves.x + waves.y, waves.z + waves.w);

--- a/shaders/simple.vert
+++ b/shaders/simple.vert
@@ -73,8 +73,8 @@ void main()
     }
 
     vec3 objectPositionInWorldSpace = vec3(modelMatrix[3][0], modelMatrix[3][1], modelMatrix[3][2]);
-    //positionInWorldSpace = applyMainBending(positionInWorldSpace - objectPositionInWorldSpace, windForce);
-    //positionInWorldSpace += objectPositionInWorldSpace;
+    positionInWorldSpace = applyMainBending(positionInWorldSpace - objectPositionInWorldSpace, windForce);
+    positionInWorldSpace += objectPositionInWorldSpace;
 
     positionInWorldSpace = applyDetailBending(positionInWorldSpace, objectPositionInWorldSpace, time);
 
@@ -104,7 +104,7 @@ vec3 applyMainBending(vec3 positionInWorldSpace, vec3 windForce) {
     vertexHeight = vertexHeight * vertexHeight - vertexHeight;
 
     vec3 newPos = positionInWorldSpace;
-    newPos.xy += windForce.xy * vertexHeight;
+    newPos.xz += windForce.xz * vertexHeight;
 
     float oldLength = length(positionInWorldSpace);
 
@@ -112,7 +112,7 @@ vec3 applyMainBending(vec3 positionInWorldSpace, vec3 windForce) {
 }
 
 vec3 applyDetailBending(vec3 positionInWorldSpace, vec3 objectPositionInWorldSpace, float time) {
-    float branchAmplitude = 10.0;
+    float branchAmplitude = 5.0;
     float branchStiffness = vertexColor.b;
 
     // Each object has its own phase to allow us to give different animations to different identical objects

--- a/shaders/simple.vert
+++ b/shaders/simple.vert
@@ -96,7 +96,7 @@ void main()
 	vec3 N = normalize(normalMatrix * vec4(normalIn, 0.0)).xyz;
 	TBN = mat3(T, B, N);
 
-	color = vec4(vertexColor.b, vertexColor.g, vertexColor.b, 1);
+	color = vec4(vertexColor.r, vertexColor.g, vertexColor.b, 1);
 	texCoord = texCoordIn;
 
 	viewSpacePosition = modelViewMatrix * vec4(positionInWorldSpace, 1.0);

--- a/src/common/Utils.cpp
+++ b/src/common/Utils.cpp
@@ -97,3 +97,7 @@ void updateMinAndMax(const float x, const float y, const float z, chag::float3* 
 chag::float3 createRandomVector(const float minValue, const float maxValue){
     return chag::make_vector(getRand(minValue,maxValue), getRand(minValue,maxValue), getRand(minValue,maxValue));
 }
+
+chag::float3 linearSmoothStep(chag::float3 v1, chag::float3 v2, float time) {
+    return v1 + time * (v2 - v1);
+}

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -63,10 +63,10 @@ void Renderer::resize(unsigned int width, unsigned int height) {
     horizontalBlurFbo = createPostProcessFbo(width, height);
 }
 
-void Renderer::drawModel(IDrawable &model, std::shared_ptr<ShaderProgram> &shaderProgram)
+void Renderer::drawModel(const std::shared_ptr<IDrawable> &model, std::shared_ptr<ShaderProgram> &shaderProgram)
 {
     shaderProgram->use();
-    model.render();
+    model->render();
 }
 
 void Renderer::drawScene(Camera *camera, Scene *scene, float currentTime)
@@ -229,9 +229,10 @@ void Renderer::setLights(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *s
 */
 void Renderer::drawShadowCasters(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene) {
     std::vector<std::shared_ptr<GameObject>> shadowCasters = scene->getShadowCasters();
-    for (unsigned int i = 0; i < scene->getShadowCasters().size(); i++) {
-        shaderProgram->setUniform1f("object_reflectiveness", (*shadowCasters[i]).shininess);
-        drawModel(*shadowCasters[i], shaderProgram);
+
+    for(auto shadowCaster : shadowCasters) {
+        shaderProgram->setUniform1f("object_reflectiveness", shadowCaster->shininess);
+        drawModel(shadowCaster, shaderProgram);
     }
 }
 
@@ -239,11 +240,12 @@ void Renderer::drawTransparent(std::shared_ptr<ShaderProgram> &shaderProgram, Sc
     shaderProgram->use();
     std::vector<std::shared_ptr<GameObject>> transparentObjects = scene->getTransparentObjects();
 
-    for (unsigned int i = 0; i < transparentObjects.size(); i++) {
+    for (auto transparentObject : transparentObjects) {
         glEnable(GL_BLEND);
         glDepthFunc(GL_LESS);
-        shaderProgram->setUniform1f("object_reflectiveness", (*transparentObjects[i]).shininess);
-        drawModel(*transparentObjects[i], shaderProgram);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        shaderProgram->setUniform1f("object_reflectiveness", transparentObject->shininess);
+        drawModel(transparentObject, shaderProgram);
     }
 }
 

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -123,7 +123,7 @@ void Renderer::drawScene(Camera *camera, Scene *scene, float currentTime)
     shaderProgram->setUniformMatrix4fv("viewMatrix", viewMatrix);
     shaderProgram->setUniform1f("time", currentTime);
 
-    setWind(shaderProgram);
+    setWind(shaderProgram, scene->getWind());
 
     setLights(shaderProgram, scene);
 
@@ -164,23 +164,8 @@ void Renderer::drawScene(Camera *camera, Scene *scene, float currentTime)
 
 }
 
-void Renderer::setWind(std::shared_ptr<ShaderProgram> shaderProgram) {
-    if(currentTime - lastWindChangeTime > 1.0f) {
-        lastWindChangeTime += 1;
-        lastWindSpeed = newWindSpeed;
-        float x = getRand(0, 1);
-        float y = getRand(0, 1);
-        float z = getRand(0, 1);
-
-        newWindSpeed.x = x * 2.0f - 1.0f;
-        newWindSpeed.y = y * 2.0f - 1.0f;
-        newWindSpeed.z = z * 2.0f - 1.0f;
-
-    }
-
-    currentWindSpeed = linearSmoothStep(lastWindSpeed, newWindSpeed, currentTime - lastWindChangeTime);
-    effects.wind.force = currentWindSpeed;
-    shaderProgram->setUniform3f("windForce", effects.wind.force);
+void Renderer::setWind(std::shared_ptr<ShaderProgram> shaderProgram, const std::shared_ptr<Wind> wind) {
+    shaderProgram->setUniform3f("windForce", wind->getForce());
 }
 
 void Renderer::setLights(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene) {
@@ -232,6 +217,10 @@ void Renderer::drawShadowCasters(std::shared_ptr<ShaderProgram> &shaderProgram, 
 
     for(auto shadowCaster : shadowCasters) {
         shaderProgram->setUniform1f("object_reflectiveness", shadowCaster->shininess);
+        shaderProgram->setUniform1i("isAffectedByWind", shadowCaster->getIsAffectedByWind());
+        shaderProgram->setUniform1f("branchAmplitude", shadowCaster->getBranchAmplitude());
+        shaderProgram->setUniform1f("leafAmplitude", shadowCaster->getLeafAmplitude());
+        shaderProgram->setUniform1f("mainBendiness", shadowCaster->getMainBendiness());
         drawModel(shadowCaster, shaderProgram);
     }
 }
@@ -245,6 +234,10 @@ void Renderer::drawTransparent(std::shared_ptr<ShaderProgram> &shaderProgram, Sc
         glDepthFunc(GL_LESS);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         shaderProgram->setUniform1f("object_reflectiveness", transparentObject->shininess);
+        shaderProgram->setUniform1i("isAffectedByWind", transparentObject->getIsAffectedByWind());
+        shaderProgram->setUniform1f("branchAmplitude", transparentObject->getBranchAmplitude());
+        shaderProgram->setUniform1f("leafAmplitude", transparentObject->getLeafAmplitude());
+        shaderProgram->setUniform1f("mainBendiness", transparentObject->getMainBendiness());
         drawModel(transparentObject, shaderProgram);
     }
 }

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -217,10 +217,7 @@ void Renderer::drawShadowCasters(std::shared_ptr<ShaderProgram> &shaderProgram, 
 
     for(auto shadowCaster : shadowCasters) {
         shaderProgram->setUniform1f("object_reflectiveness", shadowCaster->shininess);
-        shaderProgram->setUniform1i("isAffectedByWind", shadowCaster->getIsAffectedByWind());
-        shaderProgram->setUniform1f("branchAmplitude", shadowCaster->getBranchAmplitude());
-        shaderProgram->setUniform1f("leafAmplitude", shadowCaster->getLeafAmplitude());
-        shaderProgram->setUniform1f("mainBendiness", shadowCaster->getMainBendiness());
+        setWindUniforms(shaderProgram, shadowCaster);
         drawModel(shadowCaster, shaderProgram);
     }
 }
@@ -234,12 +231,17 @@ void Renderer::drawTransparent(std::shared_ptr<ShaderProgram> &shaderProgram, Sc
         glDepthFunc(GL_LESS);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         shaderProgram->setUniform1f("object_reflectiveness", transparentObject->shininess);
-        shaderProgram->setUniform1i("isAffectedByWind", transparentObject->getIsAffectedByWind());
-        shaderProgram->setUniform1f("branchAmplitude", transparentObject->getBranchAmplitude());
-        shaderProgram->setUniform1f("leafAmplitude", transparentObject->getLeafAmplitude());
-        shaderProgram->setUniform1f("mainBendiness", transparentObject->getMainBendiness());
+        setWindUniforms(shaderProgram, transparentObject);
         drawModel(transparentObject, shaderProgram);
     }
+}
+
+void Renderer::setWindUniforms(std::shared_ptr<ShaderProgram> &shaderProgram,
+                               const std::shared_ptr<GameObject> &shadowCaster) const {
+    shaderProgram->setUniform1i("isAffectedByWind", shadowCaster->getIsAffectedByWind());
+    shaderProgram->setUniform1f("branchAmplitude", shadowCaster->getBranchAmplitude());
+    shaderProgram->setUniform1f("leafAmplitude", shadowCaster->getLeafAmplitude());
+    shaderProgram->setUniform1f("mainBendiness", shadowCaster->getMainBendiness());
 }
 
 void Renderer::drawBloom(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene, int w, int h, chag::float4x4 &viewProjectionMatrix) {

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -174,7 +174,7 @@ void Renderer::setWind(std::shared_ptr<ShaderProgram> shaderProgram) {
 
         newWindSpeed.x = x * 2.0f - 1.0f;
         newWindSpeed.y = y * 2.0f - 1.0f;
-        //newWindSpeed.z = -z * 2.0f;
+        newWindSpeed.z = z * 2.0f - 1.0f;
 
     }
 

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -121,6 +121,9 @@ void Renderer::drawScene(Camera *camera, Scene *scene, float currentTime)
     shaderProgram->setUniformMatrix4fv("inverseViewNormalMatrix", transpose(viewMatrix));
     shaderProgram->setUniform3f("viewPosition", camera->getPosition());
     shaderProgram->setUniformMatrix4fv("viewMatrix", viewMatrix);
+    shaderProgram->setUniform1f("time", currentTime);
+
+    setWind(shaderProgram);
 
     setLights(shaderProgram, scene);
 
@@ -159,6 +162,25 @@ void Renderer::drawScene(Camera *camera, Scene *scene, float currentTime)
     //Cleanup
     glUseProgram(0);
 
+}
+
+void Renderer::setWind(std::shared_ptr<ShaderProgram> shaderProgram) {
+    if(currentTime - lastWindChangeTime > 1.0f) {
+        lastWindChangeTime = currentTime;
+        lastWindSpeed = currentWindSpeed;
+        float x = getRand(0, 1);
+        float y = getRand(0, 1);
+        float z = getRand(0, 1);
+
+        newWindSpeed.x = x * 2.0f - 1.0f;
+        newWindSpeed.y = y * 2.0f - 1.0f;
+        newWindSpeed.z = -z * 2.0f;
+
+    }
+
+    currentWindSpeed = linearSmoothStep(currentWindSpeed, newWindSpeed, currentTime - lastWindChangeTime);
+    effects.wind.force = currentWindSpeed;
+    shaderProgram->setUniform3f("windForce", effects.wind.force);
 }
 
 void Renderer::setLights(std::shared_ptr<ShaderProgram> &shaderProgram, Scene *scene) {

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -174,7 +174,7 @@ void Renderer::setWind(std::shared_ptr<ShaderProgram> shaderProgram) {
 
         newWindSpeed.x = x * 2.0f - 1.0f;
         newWindSpeed.y = y * 2.0f - 1.0f;
-        newWindSpeed.z = -z * 2.0f;
+        //newWindSpeed.z = -z * 2.0f;
 
     }
 

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -166,8 +166,8 @@ void Renderer::drawScene(Camera *camera, Scene *scene, float currentTime)
 
 void Renderer::setWind(std::shared_ptr<ShaderProgram> shaderProgram) {
     if(currentTime - lastWindChangeTime > 1.0f) {
-        lastWindChangeTime = currentTime;
-        lastWindSpeed = currentWindSpeed;
+        lastWindChangeTime += 1;
+        lastWindSpeed = newWindSpeed;
         float x = getRand(0, 1);
         float y = getRand(0, 1);
         float z = getRand(0, 1);
@@ -178,7 +178,7 @@ void Renderer::setWind(std::shared_ptr<ShaderProgram> shaderProgram) {
 
     }
 
-    currentWindSpeed = linearSmoothStep(currentWindSpeed, newWindSpeed, currentTime - lastWindChangeTime);
+    currentWindSpeed = linearSmoothStep(lastWindSpeed, newWindSpeed, currentTime - lastWindChangeTime);
     effects.wind.force = currentWindSpeed;
     shaderProgram->setUniform3f("windForce", effects.wind.force);
 }

--- a/src/glutil/glutil.cpp
+++ b/src/glutil/glutil.cpp
@@ -189,7 +189,7 @@ namespace
 #			if defined(_WIN32)
 			__debugbreak();
 #			else // !win32
-			assert(false);
+//			assert(false);
 #			endif // ~ platform
 		}
 	}

--- a/src/glutil/glutil.cpp
+++ b/src/glutil/glutil.cpp
@@ -189,7 +189,7 @@ namespace
 #			if defined(_WIN32)
 			__debugbreak();
 #			else // !win32
-//			assert(false);
+
 #			endif // ~ platform
 		}
 	}

--- a/src/objects/CMakeLists.txt
+++ b/src/objects/CMakeLists.txt
@@ -7,5 +7,7 @@ set(BUBBA3D_FILES_SOURCE objects/Chunk.cpp
                          objects/Triangle.cpp
                          objects/BoneInfluenceOnVertex.cpp
                          objects/BoneTransformer.cpp
+                         objects/WindAffection.cpp
+                         objects/Wind.cpp
                          ${BUBBA3D_FILES_SOURCE}
                          PARENT_SCOPE)

--- a/src/objects/Mesh.cpp
+++ b/src/objects/Mesh.cpp
@@ -19,19 +19,11 @@
 #include "Logger.h"
 #include "Triangle.h"
 
-#include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>
-#include <assimp/scene.h>
-#include <vector>
 #include "Chunk.h"
-#include <string>
-#include "Utils.h"
-#include "GL/glew.h"
-#include "BoneMatrices.h"
 #include "Utils.h"
 #include "linmath/float3x3.h"
 #include "BoneTransformer.h"
-#include "Texture.h"
 
 using namespace chag;
 
@@ -82,7 +74,6 @@ void Mesh::initChunkFromAiMesh(const aiMesh *paiMesh, Chunk &chunk) {
     initIndicesFromAiMesh(paiMesh, chunk);
 
     initBonesFromAiMesh(paiMesh, chunk);
-
 
     chunk.materialIndex = paiMesh->mMaterialIndex;
 
@@ -284,6 +275,7 @@ void Mesh::setupChunkForRendering(Chunk &chunk) {
     glBindVertexArray(chunk.m_vaob);
 
     setupGlBuffer(chunk.m_positions, &chunk.m_positions_bo, 0, 3 , &chunk.m_positions[0].x, GL_ARRAY_BUFFER_ARB, GL_FLOAT);
+
     setupGlBuffer(chunk.m_normals, &chunk.m_normals_bo, 1, 3, &chunk.m_normals[0].x, GL_ARRAY_BUFFER_ARB, GL_FLOAT);
 
     if (chunk.m_uvs.size() > 0) {

--- a/src/objects/Mesh.cpp
+++ b/src/objects/Mesh.cpp
@@ -123,8 +123,7 @@ void Mesh::initVerticesFromAiMesh(const aiMesh *paiMesh, Chunk &chunk) {
     }
 }
 
-chag::float3 Mesh::getVertexColors(const aiMesh *paiMesh, Chunk &chunk, unsigned int i) const {
-    chag::float3 vertexColor = chag::make_vector(0.0f, 0.0f, 0.0f);
+void Mesh::getVertexColors(const aiMesh *paiMesh, Chunk &chunk, unsigned int i) const {
     unsigned int j = 0;
     do {
             if (paiMesh->HasVertexColors(j)) {

--- a/src/objects/Mesh.cpp
+++ b/src/objects/Mesh.cpp
@@ -110,8 +110,23 @@ void Mesh::initVerticesFromAiMesh(const aiMesh *paiMesh, Chunk &chunk) {
         chunk.m_normals.push_back(make_vector(pNormal.x, pNormal.y, pNormal.z));
         chunk.m_uvs.push_back(make_vector(pTexCoord.x, pTexCoord.y));
 
-        unsigned int j = 0;
-        do {
+        getVertexColors(paiMesh, chunk, i);
+
+        if (paiMesh->HasTangentsAndBitangents()) {
+            const aiVector3D pBitTangents = paiMesh->mBitangents[i];
+            const aiVector3D pTangents = paiMesh->mTangents[i];
+            chunk.m_bittangents.push_back(make_vector(pBitTangents.x, pBitTangents.y, pBitTangents.z));
+            chunk.m_tangents.push_back(make_vector(pTangents.x, pTangents.y, pTangents.z));
+        }
+
+        updateMinAndMax(pPos.x, pPos.y, pPos.z, &aabb.minV, &aabb.maxV);
+    }
+}
+
+chag::float3 Mesh::getVertexColors(const aiMesh *paiMesh, Chunk &chunk, unsigned int i) const {
+    chag::float3 vertexColor = chag::make_vector(0.0f, 0.0f, 0.0f);
+    unsigned int j = 0;
+    do {
             if (paiMesh->HasVertexColors(j)) {
                 aiColor4D vertexColor = paiMesh->mColors[j][i];
 
@@ -126,16 +141,6 @@ void Mesh::initVerticesFromAiMesh(const aiMesh *paiMesh, Chunk &chunk) {
             }
             j++;
         } while (paiMesh->HasVertexColors(j));
-
-        if (paiMesh->HasTangentsAndBitangents()) {
-            const aiVector3D pBitTangents = paiMesh->mBitangents[i];
-            const aiVector3D pTangents = paiMesh->mTangents[i];
-            chunk.m_bittangents.push_back(make_vector(pBitTangents.x, pBitTangents.y, pBitTangents.z));
-            chunk.m_tangents.push_back(make_vector(pTangents.x, pTangents.y, pTangents.z));
-        }
-
-        updateMinAndMax(pPos.x, pPos.y, pPos.z, &aabb.minV, &aabb.maxV);
-    }
 }
 
 void Mesh::initIndicesFromAiMesh(const aiMesh *paiMesh, Chunk &chunk) {

--- a/src/objects/Mesh.cpp
+++ b/src/objects/Mesh.cpp
@@ -115,7 +115,7 @@ void Mesh::initVerticesFromAiMesh(const aiMesh *paiMesh, Chunk &chunk) {
             if (paiMesh->HasVertexColors(j)) {
                 aiColor4D vertexColor = paiMesh->mColors[j][i];
 
-                if(chunk.m_vertexColors.size() >= i) {
+                if(chunk.m_vertexColors.size() <= i) {
                     chunk.m_vertexColors.push_back(chag::make_vector(0.0f, 0.0f, 0.0f));
                 }
 

--- a/src/objects/Mesh.cpp
+++ b/src/objects/Mesh.cpp
@@ -110,12 +110,22 @@ void Mesh::initVerticesFromAiMesh(const aiMesh *paiMesh, Chunk &chunk) {
         chunk.m_normals.push_back(make_vector(pNormal.x, pNormal.y, pNormal.z));
         chunk.m_uvs.push_back(make_vector(pTexCoord.x, pTexCoord.y));
 
-        if(paiMesh->HasVertexColors(0)) {
-            aiColor4D vertexColor = paiMesh->mColors[0][i];
-            chunk.m_vertexColors.push_back(chag::make_vector(vertexColor.r, vertexColor.g, vertexColor.b));
-        } else {
-            chunk.m_vertexColors.push_back(chag::make_vector(0.0f, 0.0f, 0.0f));
-        }
+        unsigned int j = 0;
+        do {
+            if (paiMesh->HasVertexColors(j)) {
+                aiColor4D vertexColor = paiMesh->mColors[j][i];
+
+                if(chunk.m_vertexColors.size() >= i) {
+                    chunk.m_vertexColors.push_back(chag::make_vector(0.0f, 0.0f, 0.0f));
+                }
+
+                chunk.m_vertexColors[i] += chag::make_vector(vertexColor.r, vertexColor.g, vertexColor.b);
+
+            } else {
+                chunk.m_vertexColors.push_back(chag::make_vector(0.0f, 0.0f, 0.0f));
+            }
+            j++;
+        } while (paiMesh->HasVertexColors(j));
 
         if (paiMesh->HasTangentsAndBitangents()) {
             const aiVector3D pBitTangents = paiMesh->mBitangents[i];

--- a/src/objects/Scene.cpp
+++ b/src/objects/Scene.cpp
@@ -17,8 +17,8 @@
 #include "Scene.h"
 #include "GameObject.h"
 
-Scene::Scene()
-{
+Scene::Scene() {
+    this->wind = std::make_shared<Wind>();
 }
 
 
@@ -78,4 +78,12 @@ void Scene::removeDirty(std::vector<std::shared_ptr<GameObject>> *objectsInScene
             i++;
         }
     }
+}
+
+const std::shared_ptr<Wind> Scene::getWind() const {
+    return wind;
+}
+
+void Scene::setWind(const std::shared_ptr<Wind> wind) {
+    this->wind = wind;
 }

--- a/src/objects/Wind.cpp
+++ b/src/objects/Wind.cpp
@@ -1,0 +1,15 @@
+
+
+#include "Wind.h"
+
+Wind::Wind() {
+    force = chag::make_vector(0.0f, 0.0f, 0.0f);
+}
+
+Wind::Wind(const chag::float3 &force) : force(force) {
+
+}
+
+const chag::float3 &Wind::getForce() const {
+    return force;
+}

--- a/src/objects/WindAffection.cpp
+++ b/src/objects/WindAffection.cpp
@@ -1,0 +1,34 @@
+#include "WindAffection.h"
+
+
+bool WindAffection::getIsAffectedByWind() const {
+    return isAffectedByWind;
+}
+
+void WindAffection::setAffectedByWind(bool isAffectedByWind) {
+    this->isAffectedByWind = isAffectedByWind;
+}
+
+float WindAffection::getMainBendiness() const {
+    return mainBendiness;
+}
+
+void WindAffection::setMainBendiness(float mainBendiness) {
+    this->mainBendiness = mainBendiness;
+}
+
+float WindAffection::getBranchAmplitude() const {
+    return branchAmplitude;
+}
+
+void WindAffection::setBranchAmplitude(float branchAmplitude) {
+    WindAffection::branchAmplitude = branchAmplitude;
+}
+
+float WindAffection::getLeafAmplitude() const {
+    return leafAmplitude;
+}
+
+void WindAffection::setLeafAmplitude(float leafAmplitude) {
+    WindAffection::leafAmplitude = leafAmplitude;
+}

--- a/src/shader/FragmentShader.cpp
+++ b/src/shader/FragmentShader.cpp
@@ -25,16 +25,15 @@
 FragmentShader::FragmentShader(std::string shaderName) {
     shaderString = textFileRead(shaderName.c_str(), true);
     compile();
-    checkErrors();
 }
 
 void FragmentShader::compile() {
     fragmentShader = compileShader(GL_FRAGMENT_SHADER, shaderString.c_str());
-    checkErrors();
+    checkErrors(fragmentShader);
 }
 
-void FragmentShader::checkErrors() {
-    checkCompileErrors(&fragmentShader, FRAGMENT_SHADER_NAME_STRING);
+void FragmentShader::checkErrors(GLuint &shader) {
+    checkCompileErrors(&shader, FRAGMENT_SHADER_NAME_STRING);
 }
 
 GLuint FragmentShader::getGLId() {

--- a/src/shader/FragmentShader.h
+++ b/src/shader/FragmentShader.h
@@ -36,7 +36,7 @@ public:
     FragmentShader(std::string shaderName);
 
     virtual void compile();
-    virtual void checkErrors();
+    virtual void checkErrors(GLuint &shader);
     virtual GLuint getGLId();
 
 private:

--- a/src/shader/VertexShader.cpp
+++ b/src/shader/VertexShader.cpp
@@ -27,16 +27,15 @@
 VertexShader::VertexShader(std::string shaderName) {
     shaderString = textFileRead(shaderName.c_str(), true);
     compile();
-    checkErrors();
 }
 
 void VertexShader::compile() {
     vertexShader = compileShader(GL_VERTEX_SHADER, shaderString.c_str());
-    checkErrors();
+    checkErrors(vertexShader);
 }
 
-void VertexShader::checkErrors() {
-    checkCompileErrors(&vertexShader, VERTEX_SHADER_NAME_STRING);
+void VertexShader::checkErrors(GLuint &shader) {
+    checkCompileErrors(&shader, VERTEX_SHADER_NAME_STRING);
 }
 
 GLuint VertexShader::getGLId() {

--- a/src/shader/VertexShader.h
+++ b/src/shader/VertexShader.h
@@ -40,7 +40,7 @@ public:
     VertexShader(std::string shaderName);
 
     virtual void compile();
-    virtual void checkErrors();
+    virtual void checkErrors(GLuint &shader);
     virtual GLuint getGLId();
 
 private:


### PR DESCRIPTION
How an object is affected by wind is painted as vertex colors on the object as described in https://mtnphil.wordpress.com/2011/10/18/wind-animations-for-vegetation/ with the difference that the branch attenuation is inverted when coloring, not in shaders.

A scene now has a global wind. Objects are by default not affected by it, but can be if affectedByWind attribute is set on it. 
An object can be affected in three different ways; stem, branch and leaf bending (see article above), which are specified on the object itself. (It needs to be on the GameObject as the renderer sets this information)

